### PR TITLE
Wait for panels state=Done

### DIFF
--- a/grafanimate/marionette.py
+++ b/grafanimate/marionette.py
@@ -4,6 +4,7 @@
 import atexit
 import json
 import logging
+import time
 from collections import OrderedDict
 
 import where
@@ -170,6 +171,16 @@ class FirefoxMarionetteBase(object):
         """
         Return screenshot from element.
         """
+        while True:
+            result = self.marionette.execute_script('''
+            panels = Object.values(window.wrappedJSObject.grafanaRuntime.getPanelData())
+            return panels.length && panels.every(function(o) {return o?.state=='Done'})
+            ''')
+            if result:
+                break
+            logger.info("waiting for panels to load")
+            time.sleep(0.1)
+
         image = self.marionette.screenshot(element=element, format="binary")
         return image
 


### PR DESCRIPTION
Alternative method to use-panel-events and exposure-time options.
I think it still needs ~0.2 second exposure time.
Also not tested with older versions of Grafana.

I have been using grafanimate with some customizations to post videos of my Grafana to X/Twitter
https://x.com/IntermittentNRG/status/1712826595977674850

Submitted for your consideration.