### PR TITLE
CI: Fix workflow permissions to permit the recipe to upload to GHCR

### DIFF
--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -44,6 +44,13 @@ env:
 jobs:
 
   oci:
+
+    # Fix workflow permissions to permit the recipe to upload to GHCR.
+    # https://github.com/docker/build-push-action/issues/687#issuecomment-1651816012
+    permissions:
+      contents: read
+      packages: write
+
     runs-on: ubuntu-22.04
     if: ${{ ! (startsWith(github.actor, 'dependabot') || github.event.pull_request.head.repo.fork ) }}
 


### PR DESCRIPTION
I don't know why this suddenly went south. The reason why it fails is apparently the lack of permissions for the workflow. Recommended setting would be the topmost item, "read and write permissions".

![image](https://github.com/user-attachments/assets/858c053d-41b8-4d23-a004-889c4052839e)

- See also: https://github.com/docker/build-push-action/issues/687