### PR TITLE
Optionally configure Firefox location using `FIREFOX_BIN` env var

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ grafanimate changelog
 
 in progress
 ===========
+- Optionally configure Firefox location using ``FIREFOX_BIN``
+  environment variable. Thanks, @gogglespisano and @intermittentnrg.
 
 2024-12-03 0.8.0
 ================

--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,16 @@ line options, please invoke:
 
     grafanimate --help
 
+Configuration
+=============
+
+Firefox Location
+----------------
+grafanimate will discover a Firefox installation on your system path.
+If you need to configure a specific installation location, use the
+environment variable ``FIREFOX_BIN`` to point to the Firefox executable
+on your system.
+
 Examples
 ========
 

--- a/grafanimate/marionette.py
+++ b/grafanimate/marionette.py
@@ -3,6 +3,7 @@
 import atexit
 import json
 import logging
+import os
 from collections import OrderedDict
 
 import where
@@ -109,10 +110,10 @@ class FirefoxMarionetteBase:
 
     @classmethod
     def find_firefox(cls):
-        candidates = []
-        candidates += where.where("firefox-bin")
-        candidates += where.where("firefox-esr")
-        candidates += [
+        candidates = [
+            os.environ.get("FIREFOX_BIN"),
+            where.where("firefox-bin"),
+            where.where("firefox-esr"),
             "/Applications/Firefox.app/Contents/MacOS/firefox-bin",
         ]
         firefox = find_program_candidate(candidates)


### PR DESCRIPTION
## About
This patch intends to improve configuring the Firefox path using the `FIREFOX_BIN` environment variable, for those who need it.
- GH-18
